### PR TITLE
Update roboclaw_driver.py

### DIFF
--- a/roboclaw_node/src/roboclaw_driver/roboclaw_driver.py
+++ b/roboclaw_node/src/roboclaw_driver/roboclaw_driver.py
@@ -340,7 +340,7 @@ def _write1(address, cmd, val):
     return False
 
 
-def _write111(address, cmd, val1, val2):
+def _write11(address, cmd, val1, val2):
     trys = _trystimeout
     while trys:
         _sendcommand(address, cmd)
@@ -1083,7 +1083,7 @@ def ReadPinFunctions(address):
 
 
 def SetDeadBand(address, min, max):
-    return _write111(address, Cmd.SETDEADBAND, min, max)
+    return _write11(address, Cmd.SETDEADBAND, min, max)
 
 
 def GetDeadBand(address):


### PR DESCRIPTION
typo with _write111 having too many 1's and setdeadband calling it, probably not an issue but might as well fix what's broken or at least inconsistent.